### PR TITLE
Add Cursor IDE guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ This command will start the following components:
 
 ## Development
 
+For guidance on using the Cursor IDE with this repository, see [docs/cursor_integration.md](docs/cursor_integration.md).
+
 The project's Python components are organized as follows:
 
 ### Core Components

--- a/docs/cursor_integration.md
+++ b/docs/cursor_integration.md
@@ -1,0 +1,31 @@
+# Using Cursor IDE with Yeshie
+
+This guide explains how to set up the Cursor IDE as a standalone application and connect it to the Yeshie project. It also covers built‑in features like inline chat and automated pull‑request review.
+
+## Obtain the Cursor IDE
+
+1. Visit [https://www.cursor.sh/](https://www.cursor.sh/) and download the installer for your platform.
+2. Run the installer and follow the prompts to install the application.
+3. Launch **Cursor** from your applications menu or start menu.
+
+## Open this Project in Cursor
+
+1. In the Cursor window, choose **Clone Repository** from the welcome screen or **File → Clone Repository**.
+2. Enter the repository URL for Yeshie or select a local path if you have already cloned it.
+3. Cursor will open the project in a familiar VS Code‑style interface.
+
+## Built‑in AI Features
+
+Cursor includes several AI tools that can assist with development:
+
+- **Inline Chat** – highlight code and press `Cmd/Ctrl+K` to ask questions or request edits directly within the editor.
+- **Commit Message Generation** – when committing changes, Cursor can suggest commit messages.
+- **Pull Request Review** – open a PR and use the "Review with AI" button to generate review comments.
+- **Codebase Search** – natural‑language search across files with the shortcut `Cmd/Ctrl+L`.
+
+These features can speed up code understanding and review tasks.
+
+## Notes on Extensions
+
+Cursor ships as a complete editor, so you do **not** need to install a separate VS Code extension. If you previously used the Cursor extension inside VS Code, you can uninstall it and run the standalone IDE instead.
+


### PR DESCRIPTION
## Summary
- create `docs/cursor_integration.md` describing how to use Cursor IDE
- link to the new guide from the Development section in README

## Testing
- `pnpm run test:python`
- `pnpm test` *(fails: vitest not found)*