### PR TITLE
Fix tab history filtering and UI loading

### DIFF
--- a/extension/background/tabHistory.ts
+++ b/extension/background/tabHistory.ts
@@ -17,11 +17,11 @@ export interface TabInfo {
 let lastTabFocusTime = 0;
 const debouncedUpdateTabs = debounce(updateStoredTabs, 1000);
 
-// Utility: Check extension/internal URLs
+// Utility: Check URLs that should be ignored
+// Allow chrome:// and chrome-extension:// pages to be tracked
+// Only ignore internal about: pages or the extension root URL
 const isExtensionUrl = (url: string) =>
   url.startsWith(EXTENSION_URL_PATTERN) ||
-  url.startsWith("chrome://") ||
-  url.startsWith("chrome-extension://") ||
   url.startsWith("about:");
 
 // Initialize listeners

--- a/extension/tabs/index.tsx
+++ b/extension/tabs/index.tsx
@@ -770,15 +770,20 @@ function TabsIndex() {
   useEffect(() => {
     async function runInstructionsIfPresent() {
       // Wait for the button to appear before running the test
-      const waitForButton = (selector: string, timeout = 3000): Promise<void> => new Promise((resolve, reject) => {
-        const start = Date.now();
-        function check() {
-          if (document.querySelector(selector)) return resolve();
-          if (Date.now() - start > timeout) return reject();
-          setTimeout(check, 50);
-        }
-        check();
-      });
+      const waitForButton = (
+        selector: string,
+        timeout = 3000,
+        interval = 200
+      ): Promise<void> =>
+        new Promise((resolve, reject) => {
+          const start = Date.now();
+          const check = () => {
+            if (document.querySelector(selector)) return resolve();
+            if (Date.now() - start > timeout) return reject();
+            setTimeout(check, interval);
+          };
+          check();
+        });
 
       if (!runScriptOnReload) { // Check the toggle state
         logInfo('UI', 'runInstructionsIfPresent: Auto-run disabled by user toggle.');
@@ -1295,10 +1300,6 @@ function TabsIndex() {
 }
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);
-root.render(
-  <React.StrictMode>
-   ""
-  </React.StrictMode>
-); 
+root.render(<TabsIndex />);
 
 export default TabsIndex;


### PR DESCRIPTION
## Summary
- include chrome URLs in tab history tracking
- throttle DOM polling for auto-run checks
- render tabs UI normally without placeholder strict mode

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*