### PR TITLE
Implement command execution in background

### DIFF
--- a/client/src/tests/backgroundCommand.test.ts
+++ b/client/src/tests/backgroundCommand.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+import { executeCommand } from '../../../extension/background/messages/command'
+
+vi.mock('../../../extension/functions/Stepper', () => ({
+  Stepper: vi.fn(async () => 'ok')
+}))
+
+describe('background command handler', () => {
+  it('returns success result from Stepper', async () => {
+    const res = await executeCommand('click #id')
+    expect(res.success).toBe(true)
+    expect(res.result).toBe('ok')
+  })
+
+  it('returns error when Stepper throws', async () => {
+    const mod = await import('../../../extension/functions/Stepper')
+    const StepperMock = mod.Stepper as unknown as vi.Mock
+    StepperMock.mockRejectedValueOnce(new Error('fail'))
+    const res = await executeCommand('bad')
+    expect(res.success).toBe(false)
+    expect(res.error).toBe('fail')
+  })
+})

--- a/extension/background/messages/command.ts
+++ b/extension/background/messages/command.ts
@@ -1,12 +1,48 @@
 import type { PlasmoMessaging } from "@plasmohq/messaging"
+import { Stepper } from "../../functions/Stepper"
+import { logInfo, logError } from "../../functions/logger"
 
-const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
-  const { command, sessionId } = req.body
-  
-  // TODO: Implement actual command execution logic
-  res.send({
-    success: true
-  })
+export interface CommandRequest {
+  command: unknown
+  sessionId?: string
 }
 
-export default handler 
+export interface CommandResponse {
+  success: boolean
+  result?: unknown
+  error?: string
+}
+
+/**
+ * Execute a Stepper command payload and return the result.
+ * Separated for easier unit testing.
+ */
+export async function executeCommand (
+  command: unknown,
+  sessionId?: string
+): Promise<CommandResponse> {
+  if (command === undefined || command === null) {
+    const errorMsg = "No command provided"
+    logError("BGCommand", errorMsg)
+    return { success: false, error: errorMsg }
+  }
+
+  try {
+    const result = await Stepper(command as any)
+    logInfo("BGCommand", "Command executed", { command, sessionId, result })
+    return { success: true, result }
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logError("BGCommand", "Command execution failed", { error: errorMsg })
+    return { success: false, error: errorMsg }
+  }
+}
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const { command, sessionId } = req.body as CommandRequest
+
+  const response = await executeCommand(command, sessionId)
+  res.send(response)
+}
+
+export default handler


### PR DESCRIPTION
## Summary
- implement background command handler using `Stepper`
- add interface types and logging for success/error
- unit tests cover success and error paths

## Testing
- `pnpm test:client` *(fails: vitest not found)*