### PR TITLE
Add tab management icons and basic MCP server

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,9 @@
+# Remaining Tasks
+
+The following features were requested but are not yet fully implemented:
+
+- Cross-profile communication and organizing window lists by profile.
+- Robust bug fixes and tests for the Speech Input component.
+- Ensure the Speech Input is used for all user input and auto-focuses on the active tab/component.
+
+Future work should address these items.

--- a/client/src/tests/speechInput.test.tsx
+++ b/client/src/tests/speechInput.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { SpeechInput } from '../../../extension/components/SpeechEditor';
+
+// Simple smoke test to ensure component renders and accepts text
+
+describe('SpeechInput', () => {
+  it('renders textarea and accepts typing', () => {
+    const { getByPlaceholderText } = render(<SpeechInput initialText="" />);
+    const textarea = getByPlaceholderText(/enter text/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+    expect(textarea.value).toBe('hello');
+  });
+});

--- a/extension/tabs/TabList.tsx
+++ b/extension/tabs/TabList.tsx
@@ -2,7 +2,15 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { sendToBackground } from '@plasmohq/messaging';
 import { storageGet, storageSet } from "../functions/storage"; // Import new storage functions
 import { logInfo, logError } from "../functions/logger";
-import { APPLICATION_TABS_KEY, type StoredApplicationTab } from '../background/tabHistory';
+import { APPLICATION_TABS_KEY } from '../background/tabHistory';
+import { FiExternalLink, FiArrowRight, FiTrash2, FiSave, FiXCircle } from 'react-icons/fi';
+
+interface StoredApplicationTab {
+  id: number;
+  url?: string;
+  title?: string;
+  index?: number;
+}
 
 interface TabInfo {
   id: number;
@@ -25,6 +33,7 @@ interface WindowNameMap {
 
 const TAB_NAMES_STORAGE_KEY = 'yeshieTabCustomNames'; // Key for chrome.storage
 const WINDOW_NAMES_STORAGE_KEY = 'yeshieWindowCustomNames'; // New key for window names
+const SAVED_PAGES_KEY = 'yeshieSavedPages';
 
 // Helper to check for restricted URLs
 const isRestrictedUrl = (url: string | undefined): boolean => {
@@ -325,6 +334,49 @@ const TabList: React.FC = () => {
     }
   };
 
+  const handleCloseTab = async (tabId: number) => {
+    try {
+      await chrome.tabs.remove(tabId);
+      logInfo('TabList', `Closed tab ${tabId}`);
+    } catch (error) {
+      logError('TabList', `Failed to close tab ${tabId}`, { error });
+    }
+  };
+
+  const handleSaveAndCloseTab = async (tab: StoredApplicationTab) => {
+    try {
+      const saved = (await storageGet<StoredApplicationTab[]>(SAVED_PAGES_KEY)) || [];
+      saved.push(tab);
+      await storageSet(SAVED_PAGES_KEY, saved);
+      logInfo('TabList', `Saved tab ${tab.id}`);
+      await chrome.tabs.remove(tab.id);
+    } catch (error) {
+      logError('TabList', `Failed to save and close tab ${tab.id}`, { error });
+    }
+  };
+
+  const handleCloseWindow = async (windowId: string) => {
+    try {
+      await chrome.windows.remove(Number(windowId));
+      logInfo('TabList', `Closed window ${windowId}`);
+    } catch (error) {
+      logError('TabList', `Failed to close window ${windowId}`, { error });
+    }
+  };
+
+  const handleSaveWindow = async (windowId: string) => {
+    try {
+      const tabs = groupedTabs[windowId] || [];
+      const saved = (await storageGet<StoredApplicationTab[]>(SAVED_PAGES_KEY)) || [];
+      saved.push(...tabs);
+      await storageSet(SAVED_PAGES_KEY, saved);
+      logInfo('TabList', `Saved window ${windowId}`);
+      await chrome.windows.remove(Number(windowId));
+    } catch (error) {
+      logError('TabList', `Failed to save window ${windowId}`, { error });
+    }
+  };
+
   // --- Event Handlers for Editable Names ---
   
   // TAB Name Handlers
@@ -380,17 +432,25 @@ const TabList: React.FC = () => {
           
           return (
             <div key={windowId} className="window-group"> {/* Add class for styling */} 
-              <h3 
+              <h3
                 id={`window-header-${windowId}`}
                 className="window-header"
                 contentEditable={true}
                 suppressContentEditableWarning={true}
-                onClick={(e) => e.stopPropagation()} 
+                onClick={(e) => e.stopPropagation()}
                 onKeyDown={(e) => handleWindowNameKeyDown(e, windowId)}
                 onBlur={(e) => handleWindowNameBlur(e, windowId)}
                 key={`${windowId}-header`}
               >
                   {windowDisplayName}
+                  <span className="window-actions">
+                    <button className="tab-button" title="Save window" onClick={() => handleSaveWindow(windowId)}>
+                      <FiSave />
+                    </button>
+                    <button className="tab-button" title="Close window" onClick={() => handleCloseWindow(windowId)}>
+                      <FiXCircle />
+                    </button>
+                  </span>
               </h3>
               {tabsInWindow && tabsInWindow.length > 0 ? (
                   <ul className="tablist-ul"> 
@@ -402,23 +462,41 @@ const TabList: React.FC = () => {
                         <li key={tab.id} title={`ID: ${tab.id}\nIndex: ${tab.index}\nURL: ${tab.url}`} className="tab-item">
                           {/* Use index within the window group for display number */}
                           <span className="tab-number">{`${index + 1}:`}</span> 
-                          <button 
+                          <button
                               id={`visit-return-${index}`}
-                              className="tab-button visit-return" 
+                              className="tab-button visit-return"
                               onClick={() => handleVisitReturn(tab.id)}
                               title="Visit & Return"
-                              disabled={tab.id === -1} // Disable actions for placeholder control tab if needed
+                              disabled={tab.id === -1}
                           >
-                              VR
+                              <FiExternalLink />
                           </button>
-                          <button 
+                          <button
                               id={`visit-stay-${index}`}
-                              className="tab-button visit-stay" 
+                              className="tab-button visit-stay"
                               onClick={() => handleVisitStay(tab.id)}
                               title="Visit & Stay"
-                              disabled={tab.id === -1} 
+                              disabled={tab.id === -1}
                           >
-                              VS
+                              <FiArrowRight />
+                          </button>
+                          <button
+                              id={`close-${tab.id}`}
+                              className="tab-button"
+                              onClick={() => handleCloseTab(tab.id)}
+                              title="Close Tab"
+                              disabled={tab.id === -1}
+                          >
+                              <FiTrash2 />
+                          </button>
+                          <button
+                              id={`save-close-${tab.id}`}
+                              className="tab-button"
+                              onClick={() => handleSaveAndCloseTab(tab)}
+                              title="Save and Close Tab"
+                              disabled={tab.id === -1}
+                          >
+                              <FiSave />
                           </button>
                           <button 
                               id={`analyze-${tab.id}`}

--- a/extension/tabs/style.css
+++ b/extension/tabs/style.css
@@ -113,10 +113,10 @@
 .tab-item {
   display: flex;
   align-items: center;
-  padding: 4px 5px;
-  margin-bottom: 2px;
+  padding: 2px 4px;
+  margin-bottom: 1px;
   border-bottom: 1px solid #eee;
-  line-height: 1.3;
+  line-height: 1.2;
 }
 
 .tab-item:last-child {
@@ -141,8 +141,8 @@
 }
 
 .tab-button {
-  padding: 2px 6px;
-  margin-right: 4px;
+  padding: 1px 4px;
+  margin-right: 2px;
   font-size: 0.8em;
   cursor: pointer;
   border: 1px solid #ccc;
@@ -708,4 +708,11 @@ body {
   padding: 2px 5px;
   background-color: #f0f0f0;
   border-radius: 3px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.window-actions button {
+  margin-left: 4px;
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node dist/server.js",
+    "start:mcp": "node dist/mcpServer.js",
     "build": "tsc",
     "dev:server": "nodemon --watch src -e ts,tsx --exec ts-node src/server.ts",
     "dev:client": "cd client && pnpm run dev",
@@ -20,6 +21,7 @@
     "devx": "concurrently \"pnpm run dev:winmonitor\" \"pnpm run dev:extension\"",
     "dev1": "concurrently $(pnpm run --silent | grep '^dev:' | awk '{print $1}')",
     "dev:scrape": "nodemon --watch src/scrape.py --exec python src/scrape.py",
+    "dev:mcp": "ts-node src/mcpServer.ts",
     "test:client": "cd client && pnpm run test",
     "test:python": "python src/run_tests.py",
     "test": "pnpm run test:client && pnpm run test:python",

--- a/requirements.txt
+++ b/requirements.txt
@@ -170,3 +170,7 @@ wsproto==1.2.0
 yarl==1.18.3
 yt-dlp==2023.2.17
 zipp==3.21.0
+
+playwright==1.42.0
+pytest==8.0.2
+pytest-asyncio==0.23.5

--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -1,0 +1,27 @@
+import express from 'express';
+import { Server } from 'socket.io';
+import { createServer } from 'http';
+
+export function startMCPServer(port = 8123) {
+  const app = express();
+  const httpServer = createServer(app);
+  const io = new Server(httpServer, { cors: { origin: '*' } });
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  io.on('connection', (socket) => {
+    socket.on('mcp:message', (msg) => {
+      io.emit('mcp:message', msg);
+    });
+  });
+
+  httpServer.listen(port, () => {
+    console.log(`MCP server listening on ${port}`);
+  });
+}
+
+if (require.main === module) {
+  startMCPServer();
+}


### PR DESCRIPTION
## Summary
- refine tab list with icon buttons for visit, stay, close and save
- allow saving closed tabs and entire windows
- tighten spacing styles
- add simple MCP server
- add basic SpeechInput test
- include pytest and playwright in requirements
- expose scripts to run MCP server
- document follow-up tasks

## Testing
- `pnpm test:minimal` *(fails: No module named pytest)*
- `pnpm run test:client` *(fails: vitest: not found)*
- `pnpm test` *(fails: vitest not found)*