### PR TITLE
Enable multi-profile tab sharing

### DIFF
--- a/extension/background/index.ts
+++ b/extension/background/index.ts
@@ -1,6 +1,7 @@
 import { storageGet, storageSet, storageRemove } from "../functions/storage";
 import { logInfo, logWarn, logError } from "../functions/logger";
 import { initWebSocketHandlers } from "./websocket-handlers";
+import { initProfileConnector, sendTabsUpdate } from "./profileConnector";
 
 // Constants
 export const LAST_TAB_KEY = "yeshie_last_active_tab";
@@ -101,6 +102,8 @@ async function updateStoredTabs() {
   }, {});
 
   await storageSet(APPLICATION_TABS_KEY, groupedTabs);
+  // Notify other profiles of updated tabs
+  sendTabsUpdate();
 }
 
 // Debounce helper (simplified)
@@ -306,6 +309,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Initialize tab tracking
 initTabTracking();
+
+// Connect to MCP server for cross-profile tab sharing
+initProfileConnector();
 
 // Initialize WebSocket handlers
 initWebSocketHandlers();

--- a/extension/background/profileConnector.ts
+++ b/extension/background/profileConnector.ts
@@ -1,0 +1,57 @@
+import { io, Socket } from "socket.io-client";
+import { storageGet } from "../functions/storage";
+import { logInfo, logError } from "../functions/logger";
+import { APPLICATION_TABS_KEY, TabInfo } from "./tabHistory";
+
+export interface ProfileTabs {
+  profile: string;
+  windows: Record<string, TabInfo[]>;
+}
+
+const MCP_URL = "http://localhost:8123";
+
+let socket: Socket | null = null;
+let profileName = "unknown";
+const profiles: Record<string, Record<string, TabInfo[]>> = {};
+
+export async function initProfileConnector() {
+  profileName = await getProfileName();
+  try {
+    socket = io(MCP_URL);
+    socket.on("connect", () => {
+      logInfo("ProfileConnector", "Connected to MCP", { profile: profileName });
+      sendTabsUpdate();
+    });
+    socket.on("profile:tabs", (data: ProfileTabs) => {
+      profiles[data.profile] = data.windows;
+    });
+  } catch (error) {
+    logError("ProfileConnector", "Failed to connect to MCP", { error });
+  }
+}
+
+export async function getProfileName(): Promise<string> {
+  return new Promise((resolve) => {
+    if (chrome.identity && chrome.identity.getProfileUserInfo) {
+      try {
+        chrome.identity.getProfileUserInfo((info) => {
+          resolve(info.email || info.id || "unknown");
+        });
+      } catch {
+        resolve("unknown");
+      }
+    } else {
+      resolve("unknown");
+    }
+  });
+}
+
+export async function sendTabsUpdate() {
+  if (!socket || !socket.connected) return;
+  const windows = await storageGet<Record<string, TabInfo[]>>(APPLICATION_TABS_KEY) || {};
+  socket.emit("profile:tabs", { profile: profileName, windows } as ProfileTabs);
+}
+
+export function getProfiles(): Record<string, Record<string, TabInfo[]>> {
+  return { ...profiles };
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,7 +10,8 @@
     "tabs",
     "activeTab",
     "storage",
-    "notifications"
+    "notifications",
+    "identity"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/src/mcpServer.ts
+++ b/src/mcpServer.ts
@@ -15,6 +15,10 @@ export function startMCPServer(port = 8123) {
     socket.on('mcp:message', (msg) => {
       io.emit('mcp:message', msg);
     });
+
+    socket.on('profile:tabs', (data) => {
+      io.emit('profile:tabs', data);
+    });
   });
 
   httpServer.listen(port, () => {


### PR DESCRIPTION
## Summary
- broadcast tab updates via a new profile connector
- connect background scripts across profiles through MCP server
- expose profile names with chrome.identity
- propagate tab updates to other profiles
- allow server to relay profile tab messages
- request `identity` permission in manifest

## Testing
- `pnpm test` *(fails: vitest not found)*