### PR TITLE
Fix window actions and tooltip delay

### DIFF
--- a/extension/components/LogViewer.tsx
+++ b/extension/components/LogViewer.tsx
@@ -148,19 +148,21 @@ function LogViewer({ isOpen, onClose, showToast }: LogViewerProps) {
           )}
         </div>
         <div className="log-viewer-actions">
-          <button 
+          <button
               onClick={handleCopyLogs}
               className="button-copy"
               disabled={loading || logs.length === 0}
-              title="Copy currently displayed logs to clipboard"
+              data-tooltip="Copy currently displayed logs to clipboard"
+              aria-label="Copy currently displayed logs to clipboard"
           >
             Copy Logs
           </button>
-          <button 
-              onClick={handleClearLogs} 
-              className="button-secondary" 
+          <button
+              onClick={handleClearLogs}
+              className="button-secondary"
               disabled={loading || logs.length === 0}
-              title="Clear logs from storage for this session"
+              data-tooltip="Clear logs from storage for this session"
+              aria-label="Clear logs from storage for this session"
           >
             Clear Logs
           </button>

--- a/extension/components/SpeechEditor.tsx
+++ b/extension/components/SpeechEditor.tsx
@@ -918,7 +918,8 @@ export const SpeechInput = ({
                 type="button"
                 onClick={handleToggleListen}
                 className={getMicButtonClass()}
-                title={isTranscribing ? 'Stop Transcribing (Mic On)' : 'Start Transcribing (Mic Off)'}
+                data-tooltip={isTranscribing ? 'Stop Transcribing (Mic On)' : 'Start Transcribing (Mic Off)'}
+                aria-label={isTranscribing ? 'Stop Transcribing (Mic On)' : 'Start Transcribing (Mic Off)'}
                 disabled={!isSupported || permissionStatus === 'denied'}
                 style={{
                     position: 'absolute',
@@ -966,7 +967,8 @@ export const SpeechInput = ({
                 <button
                     type="button"
                     onClick={handleCopyDebugInfo}
-                    title="Copy Debug Logs & Text"
+                    data-tooltip="Copy Debug Logs & Text"
+                    aria-label="Copy Debug Logs & Text"
                      style={{
                         padding: '5px 10px',
                         fontSize: '0.8rem',

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,6 +8,7 @@
     "clipboardRead",
     "scripting",
     "tabs",
+    "windows",
     "activeTab",
     "storage",
     "notifications",

--- a/extension/tabs/TabList.tsx
+++ b/extension/tabs/TabList.tsx
@@ -482,10 +482,10 @@ const TabList: React.FC = () => {
               >
                   {windowDisplayName}
                   <span className="window-actions">
-                    <button className="tab-button" title="Save window" onClick={() => handleSaveWindow(windowId)}>
+                    <button className="tab-button" data-tooltip="Save window" aria-label="Save window" onClick={() => handleSaveWindow(windowId)}>
                       <FiSave />
                     </button>
-                    <button className="tab-button" title="Close window" onClick={() => handleCloseWindow(windowId)}>
+                    <button className="tab-button" data-tooltip="Close window" aria-label="Close window" onClick={() => handleCloseWindow(windowId)}>
                       <FiXCircle />
                     </button>
                   </span>
@@ -497,14 +497,15 @@ const TabList: React.FC = () => {
                             ? tabInputValues[tab.url] 
                             : (customTabNames[tab.url] || tab.title || tab.url || 'Unknown Tab');
                       return (
-                        <li key={tab.id} title={`ID: ${tab.id}\nIndex: ${tab.index}\nURL: ${tab.url}`} className="tab-item">
+                        <li key={tab.id} data-tooltip={`ID: ${tab.id}\nIndex: ${tab.index}\nURL: ${tab.url}`} className="tab-item">
                           {/* Use index within the window group for display number */}
                           <span className="tab-number">{`${index + 1}:`}</span> 
                           <button
                               id={`visit-return-${index}`}
                               className="tab-button visit-return"
                               onClick={() => handleVisitReturn(tab.id)}
-                              title="Visit & Return"
+                              data-tooltip="Visit & Return"
+                              aria-label="Visit & Return"
                               disabled={tab.id === -1}
                           >
                               <FiRefreshCw />
@@ -514,7 +515,8 @@ const TabList: React.FC = () => {
                               id={`visit-stay-${index}`}
                               className="tab-button visit-stay"
                               onClick={() => handleVisitStay(tab.id)}
-                              title="Visit & Stay"
+                              data-tooltip="Visit & Stay"
+                              aria-label="Visit & Stay"
                               disabled={tab.id === -1}
                           >
                               <FiExternalLink />
@@ -524,8 +526,8 @@ const TabList: React.FC = () => {
                               id={`close-${tab.id}`}
                               className="tab-button"
                               onClick={() => handleCloseTab(windowId, tab.id)}
-
-                              title="Close Tab"
+                              data-tooltip="Close Tab"
+                              aria-label="Close Tab"
                               disabled={tab.id === -1}
                           >
                               <FiTrash2 />
@@ -534,8 +536,8 @@ const TabList: React.FC = () => {
                               id={`save-close-${tab.id}`}
                               className="tab-button"
                               onClick={() => handleSaveAndCloseTab(windowId, tab)}
-
-                              title="Save and Close Tab"
+                              data-tooltip="Save and Close Tab"
+                              aria-label="Save and Close Tab"
                               disabled={tab.id === -1}
                           >
                               <FiSave />
@@ -545,7 +547,8 @@ const TabList: React.FC = () => {
                               className="tab-button analyze" 
                               onClick={() => handleAnalyze(tab.id, tab.url)}
                               disabled={isRestrictedUrl(tab.url) || (!tab.title && !tab.url) || tab.id === -1}
-                              title={isRestrictedUrl(tab.url) ? "Cannot analyze restricted page" : "Analyze Page (Copy HTML)"}
+                              data-tooltip={isRestrictedUrl(tab.url) ? "Cannot analyze restricted page" : "Analyze Page (Copy HTML)"}
+                              aria-label={isRestrictedUrl(tab.url) ? "Cannot analyze restricted page" : "Analyze Page (Copy HTML)"}
                           >
                               Analyze
                           </button>

--- a/extension/tabs/index.tsx
+++ b/extension/tabs/index.tsx
@@ -1020,7 +1020,8 @@ function TabsIndex() {
               className={`toast-notification ${lastErrorDetails ? 'error-toast' : ''}`}
               onClick={lastErrorDetails ? copyErrorDetailsToClipboard : undefined}
               style={lastErrorDetails ? { cursor: 'pointer' } : {}}
-              title={lastErrorDetails ? "Click to copy detailed error information" : ""}
+              data-tooltip={lastErrorDetails ? "Click to copy detailed error information" : undefined}
+              aria-label={lastErrorDetails ? "Click to copy detailed error information" : undefined}
           >
               {legacyToastMessage}
           </div>
@@ -1045,7 +1046,7 @@ function TabsIndex() {
                  Reload #{reloadCount}
              </span>
              {tabPaneFocusedTime && (
-                 <span style={{ fontSize: '0.8em', color: '#888', marginTop: '2px' }} title={new Date(tabPaneFocusedTime).toISOString()}>
+                 <span style={{ fontSize: '0.8em', color: '#888', marginTop: '2px' }} data-tooltip={new Date(tabPaneFocusedTime).toISOString()}>
                      Focused: {formatTimestamp(tabPaneFocusedTime)}
                  </span>
              )}
@@ -1060,7 +1061,8 @@ function TabsIndex() {
                  <span
                    onClick={returnToLastTab}
                    className="last-tab-link"
-                   title={`${lastTabInfo.title}\n${lastTabInfo.url}`}
+                   data-tooltip={`${lastTabInfo.title}\n${lastTabInfo.url}`}
+                   aria-label={`${lastTabInfo.title}\n${lastTabInfo.url}`}
                    style={{
                       cursor: 'pointer',
                       display: 'inline-block',
@@ -1076,7 +1078,8 @@ function TabsIndex() {
                  {/* Updated Timestamp Below Link */}
                  <span
                     className="timestamp"
-                    title={new Date(lastTabInfo.timestamp).toISOString()}
+                    data-tooltip={new Date(lastTabInfo.timestamp).toISOString()}
+                    aria-label={new Date(lastTabInfo.timestamp).toISOString()}
                     style={{ fontSize: '0.8em', color: '#888', marginTop: '2px' }}
                   >
                    Updated: {formatTimestamp(lastTabInfo.timestamp)}
@@ -1092,7 +1095,7 @@ function TabsIndex() {
             {/* API Key Section */}
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                  <span>OpenAI API Key: {hasApiKey ? 'Set ✅' : 'Not Set ❌'}</span>
-                 <button onClick={handleOpenApiKeyModal} className="settings-button" title={hasApiKey ? "Replace API Key" : "Set API Key"}>
+                 <button onClick={handleOpenApiKeyModal} className="settings-button" data-tooltip={hasApiKey ? "Replace API Key" : "Set API Key"} aria-label={hasApiKey ? "Replace API Key" : "Set API Key"}>
                      🔑
                  </button>
              </div>
@@ -1103,7 +1106,8 @@ function TabsIndex() {
                 <button
                   className="icon-button"
                   onClick={handleDownloadResults}
-                  title="Download Results"
+                  data-tooltip="Download Results"
+                  aria-label="Download Results"
                   style={{ padding: '5px' }}
                 >
                   <DownloadIcon />
@@ -1111,7 +1115,8 @@ function TabsIndex() {
                 <button
                   className="icon-button report-icon-button"
                   onClick={() => setShowReportDialog(true)}
-                  title="Report Bug or Feature"
+                  data-tooltip="Report Bug or Feature"
+                  aria-label="Report Bug or Feature"
                   style={{ padding: '5px' }}
                 >
                   <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2">
@@ -1155,7 +1160,8 @@ function TabsIndex() {
               id="log-viewer-button"
               className="icon-button log-viewer-button"
               onClick={() => setShowLogViewer(true)}
-              title="View Session Logs"
+              data-tooltip="View Session Logs"
+              aria-label="View Session Logs"
               style={{ padding: '5px' }}
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
@@ -1172,7 +1178,8 @@ function TabsIndex() {
                 onClick={handleRecordButtonClick}
                 className={`icon-button record-button ${isRecording ? 'recording' : ''}`}
                 disabled={isProcessingRecording}
-                title={isRecording ? "Stop recording user actions" : "Start recording a new test task"}
+                data-tooltip={isRecording ? "Stop recording user actions" : "Start recording a new test task"}
+                aria-label={isRecording ? "Stop recording user actions" : "Start recording a new test task"}
                 style={{ padding: '5px' }}
             >
                 <RecordIcon recording={isRecording} />
@@ -1191,7 +1198,8 @@ function TabsIndex() {
           <label 
             htmlFor="runScriptOnReloadCheckbox" 
             style={{ fontSize: '0.9em', cursor: 'pointer' }}
-            title="If checked, instructions.json will run automatically when this page loads/reloads"
+            data-tooltip="If checked, instructions.json will run automatically when this page loads/reloads"
+            aria-label="If checked, instructions.json will run automatically when this page loads/reloads"
           >
             Auto-run Script
           </label>
@@ -1222,10 +1230,11 @@ function TabsIndex() {
             onChange={handleRunScriptOnReloadChange}
             style={{ transform: 'scale(1.2)' }}
           />
-          <label 
-            htmlFor="runScriptOnReloadCheckbox" 
+          <label
+            htmlFor="runScriptOnReloadCheckbox"
             style={{ fontSize: '0.9em', cursor: 'pointer' }}
-            title="If checked, instructions.json will run automatically when this page loads/reloads"
+            data-tooltip="If checked, instructions.json will run automatically when this page loads/reloads"
+            aria-label="If checked, instructions.json will run automatically when this page loads/reloads"
           >
             Auto-run Script
           </label>
@@ -1235,7 +1244,8 @@ function TabsIndex() {
         <button
           className="icon-button"
           onClick={handleDownloadResults}
-          title="Download Last Test Results (from results.json)"
+          data-tooltip="Download Last Test Results (from results.json)"
+          aria-label="Download Last Test Results (from results.json)"
           style={{ padding: '5px 10px', display: 'flex', alignItems: 'center', gap: '5px' }}
         >
           <DownloadIcon /> Results
@@ -1245,7 +1255,8 @@ function TabsIndex() {
         <button
           className="icon-button"
           onClick={handleArchiveTest} // This function will be created next
-          title="Archive the current instructions.json to local storage"
+          data-tooltip="Archive the current instructions.json to local storage"
+          aria-label="Archive the current instructions.json to local storage"
           style={{ padding: '5px 10px', display: 'flex', alignItems: 'center', gap: '5px' }}
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg> 
@@ -1256,7 +1267,8 @@ function TabsIndex() {
           <button
             className="icon-button"
             onClick={() => setShowTestViewerDialog(true)}
-            title="View and manage archived tests"
+            data-tooltip="View and manage archived tests"
+            aria-label="View and manage archived tests"
             style={{ padding: '5px 10px', display: 'flex', alignItems: 'center', gap: '5px' }}
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>

--- a/extension/tabs/style.css
+++ b/extension/tabs/style.css
@@ -716,3 +716,29 @@ body {
 .window-actions button {
   margin-left: 4px;
 }
+
+/* Custom tooltip styling for all elements with data-tooltip */
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.75em;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s;
+  z-index: 1000;
+}
+[data-tooltip]:hover::after {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add `windows` permission for chrome windows API
- replace HTML `title` attributes with custom tooltips that show faster
- style new `[data-tooltip]` elements
- update Save/Close window buttons to work with new tooltips

## Testing
- `python -m pytest src/test_*.py` *(fails: No module named pytest)*