### PR TITLE
Fix cross profile tab display

### DIFF
--- a/extension/background/messages/getProfileName.ts
+++ b/extension/background/messages/getProfileName.ts
@@ -1,0 +1,13 @@
+import type { PlasmoMessaging } from "@plasmohq/messaging"
+import { getCurrentProfileName } from "../profileConnector"
+
+const handler: PlasmoMessaging.MessageHandler = async (_req, res) => {
+  try {
+    const profile = getCurrentProfileName()
+    res.send({ profile })
+  } catch (error) {
+    res.send({ profile: "unknown" })
+  }
+}
+
+export default handler

--- a/extension/background/messages/getProfiles.ts
+++ b/extension/background/messages/getProfiles.ts
@@ -1,0 +1,13 @@
+import type { PlasmoMessaging } from "@plasmohq/messaging"
+import { getProfiles } from "../profileConnector"
+
+const handler: PlasmoMessaging.MessageHandler = async (_req, res) => {
+  try {
+    const profiles = getProfiles()
+    res.send({ profiles })
+  } catch (error) {
+    res.send({ profiles: {} })
+  }
+}
+
+export default handler


### PR DESCRIPTION
## Summary
- define profile state and collapsed groups in TabList
- load profiles from background and listen for updates
- allow toggling profiles and windows

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module type declarations)*