### PR TITLE
Add task stubs for testing and bug fixes

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,3 +7,11 @@ The following features were requested but are not yet fully implemented:
 - Ensure the Speech Input is used for all user input and auto-focuses on the active tab/component.
 
 Future work should address these items.
+
+Additional task stubs have been created under the `tasks/` directory for upcoming work:
+- Task A – Schema validation in the Tab page.
+- Task B – Unit tests for Stepper commands.
+- Task C – Tab panel script execution tests.
+- Task D – Background command handler and UI refresh.
+- Task E – Expanded end-to-end tests.
+- Task F – Bug fixes and refactoring cleanup.

--- a/tasks/task_A_schema_validation.md
+++ b/tasks/task_A_schema_validation.md
@@ -1,0 +1,14 @@
+# Task A: Schema Validation and Instructions Loader
+
+## Summary
+Add JSON schema validation to the Tab page script loader to ensure all instruction files follow `llm-reply-schema.json`. Refuse to execute scripts that fail validation and display a helpful error toast.
+
+## Acceptance Criteria
+- [ ] Instructions are validated before execution.
+- [ ] Invalid instructions stop execution and show an error message.
+- [ ] Existing instruction files conform to the schema or are corrected.
+
+## Implementation Notes
+- Use a lightweight JSON schema validator in the Tab page (e.g., Ajv).
+- Integrate validation into the auto-run logic before iterating over tasks.
+- Provide descriptive errors in `results.json` when validation fails.

--- a/tasks/task_B_stepper_command_tests.md
+++ b/tasks/task_B_stepper_command_tests.md
@@ -1,0 +1,14 @@
+# Task B: Unit Tests for Stepper Commands
+
+## Summary
+Create unit tests covering every command supported by the Stepper component. Tests should verify expected behavior in a controlled page and include error cases for invalid selectors or command arguments.
+
+## Acceptance Criteria
+- [ ] Tests exist for all Stepper commands (navto, click, type, waitforelement, etc.).
+- [ ] Error handling is tested for missing selectors and invalid commands.
+- [ ] Tests run via the existing test runner and pass in CI.
+
+## Implementation Notes
+- Use Playwright or the existing testing framework to drive a mock page.
+- Provide fixtures for pages with known selectors to exercise each command.
+- Document any limitations or assumptions in `LLMNotes/testing`.

--- a/tasks/task_C_tab_panel_tests.md
+++ b/tasks/task_C_tab_panel_tests.md
@@ -1,0 +1,15 @@
+# Task C: Tab Panel Script Execution Tests
+
+## Summary
+Expand test coverage for the Tab page's script runner. Verify the Auto-run toggle, loading of `instructions.json`, step execution via Stepper, result writing, and archive/download behavior.
+
+## Acceptance Criteria
+- [ ] Toggling Auto-run loads instructions and begins execution automatically.
+- [ ] Steps are executed sequentially and recorded in `results.json`.
+- [ ] Success and failure toasts appear at the correct times.
+- [ ] Archived runs appear in the UI and can be downloaded.
+
+## Implementation Notes
+- Use Playwright to simulate toggling and monitor resulting behavior.
+- Mock file operations as needed to capture outputs.
+- Ensure tests run quickly by using a simple sample script.

--- a/tasks/task_D_command_handler_ui_refresh.md
+++ b/tasks/task_D_command_handler_ui_refresh.md
@@ -1,0 +1,14 @@
+# Task D: Background Command Handler and UI Refresh
+
+## Summary
+Implement the missing command execution handler in `background/messages/command.ts` and update the Tab page to refresh its task list after recordings are processed.
+
+## Acceptance Criteria
+- [ ] `command.ts` handles incoming commands and triggers appropriate Stepper actions.
+- [ ] Tab page updates its task list UI immediately after new recordings are saved.
+- [ ] No console errors occur during command handling or refresh.
+
+## Implementation Notes
+- Follow patterns from existing background message handlers.
+- Use messaging to notify the Tab page when recordings are processed.
+- Keep the UI update lightweight to avoid blocking user interactions.

--- a/tasks/task_E_e2e_tests.md
+++ b/tasks/task_E_e2e_tests.md
@@ -1,0 +1,15 @@
+# Task E: Expanded E2E Tests
+
+## Summary
+Extend Playwright end-to-end tests as described in `LLMNotes/testing/test_plan.md`. Cover GitHub login recording, command execution, error handling, and archiving of test runs.
+
+## Acceptance Criteria
+- [ ] Tests automate GitHub login flow recording and replay.
+- [ ] Command execution failures generate helpful output and screenshots.
+- [ ] Archived runs can be viewed and verified in the Tab page.
+- [ ] CI passes with the new tests on a local development server.
+
+## Implementation Notes
+- Reuse existing E2E setup in `tests/e2e`.
+- Parameterize tests with environment variables for GitHub credentials.
+- Consult the test plan for prioritization and edge cases.

--- a/tasks/task_F_bug_fixes_refactor.md
+++ b/tasks/task_F_bug_fixes_refactor.md
@@ -1,0 +1,14 @@
+# Task F: Bug Fixes and Refactoring
+
+## Summary
+Address outstanding bugs documented in `canvas/extension_review.md` and complete refactoring tasks per `refactor-plan.md` and `logging_refactor_checklist.md`. Ensure all new tests pass.
+
+## Acceptance Criteria
+- [ ] BUG-003, BUG-004, and BUG-005 are resolved with appropriate test coverage.
+- [ ] Codebase follows refactor checklist items still open.
+- [ ] No console warnings related to verbose logs or StrictMode issues.
+
+## Implementation Notes
+- Prioritize fixes that unblock other tasks, such as tab loading and focus.
+- Continue migrating console statements to the structured logger.
+- Review existing PRs or branches for partial implementations before starting.


### PR DESCRIPTION
## Summary
- add a set of task stubs under `tasks/` covering schema validation, Stepper command tests, Tab panel tests, background command handler updates, expanded E2E tests, and bug fixes
- note the new tasks in `TASKS.md`

## Testing
- `git status --short`