### PR TITLE
Integrate schema validation in tab loader

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -20,7 +20,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-toastify": "^11.0.5",
-    "socket.io-client": "^4.7.5"
+    "socket.io-client": "^4.7.5",
+    "ajv": "^8.12.0"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "4.1.1",


### PR DESCRIPTION
## Summary
- add Ajv dependency for schema validation in extension
- validate instructions before running them in the tabs page
- write validation errors to results.json

## Testing
- `pnpm test` *(fails: vitest not found)*