### PR TITLE
Fix tab listing for chrome URLs

### DIFF
--- a/extension/background/index.ts
+++ b/extension/background/index.ts
@@ -29,11 +29,11 @@ export interface TabInfo {
 let lastTabFocusTime = 0;
 const debouncedUpdateTabs = debounce(updateStoredTabs, 1000);
 
-// Utility: Check extension/internal URLs
+// Utility: Check URLs that should be ignored
+// We only ignore the extension's own pages and internal about: pages so
+// regular chrome:// and chrome-extension:// tabs are tracked as well
 const isExtensionUrl = (url: string) =>
   url.startsWith(EXTENSION_URL_PATTERN) ||
-  url.startsWith("chrome://") ||
-  url.startsWith("chrome-extension://") ||
   url.startsWith("about:");
 
 // Initialize listeners

--- a/extension/tabs/TabList.tsx
+++ b/extension/tabs/TabList.tsx
@@ -549,8 +549,11 @@ const TabList: React.FC = () => {
                        const tabDisplayName = tabInputValues[tab.url] !== undefined 
                             ? tabInputValues[tab.url] 
                             : (customTabNames[tab.url] || tab.title || tab.url || 'Unknown Tab');
+                      const shortUrl = tab.url && tab.url.length > 100
+                        ? `${tab.url.slice(0, 100)}...`
+                        : tab.url
                       return (
-                        <li key={tab.id} data-tooltip={`ID: ${tab.id}\nIndex: ${tab.index}\nURL: ${tab.url}`} className="tab-item">
+                        <li key={tab.id} data-tooltip={`ID: ${tab.id}\nIndex: ${tab.index}\nURL: ${shortUrl}`} className="tab-item">
                           {/* Use index within the window group for display number */}
                           <span className="tab-number">{`${index + 1}:`}</span> 
                           <button


### PR DESCRIPTION
## Summary
- track chrome:// and chrome-extension:// tabs
- shorten long tab URLs in tooltips

## Testing
- `pnpm test` *(fails: vitest not found)*