### PR TITLE
Add MCP server with E2E test

### DIFF
--- a/yeshie/server/mcp_server.py
+++ b/yeshie/server/mcp_server.py
@@ -1,0 +1,107 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+import asyncio
+
+app = FastAPI(
+    title="Yeshie MCP Server",
+    description="Minimal MCP server to interface with the Yeshie extension.",
+    version="0.1.0",
+)
+
+# Connected clients indexed by tab_id
+_clients: Dict[int, WebSocket] = {}
+# Futures waiting for action results
+_pending: Dict[int, asyncio.Future] = {}
+# In-memory log store
+_logs: List[Dict[str, Any]] = []
+
+
+class InitializeRequest(BaseModel):
+    client: str
+    version: str
+
+
+class InitializeResponse(BaseModel):
+    server: str
+    capabilities: List[str]
+
+
+class LogEntry(BaseModel):
+    tab_id: int
+    timestamp: str
+    log_level: str
+    message: str
+    context: Optional[Dict[str, Any]] = None
+
+
+class Action(BaseModel):
+    cmd: str
+    target: str
+    value: Optional[str] = None
+
+
+class ActionRequest(BaseModel):
+    tab_id: int
+    actions: List[Action]
+
+
+class ActionResponse(BaseModel):
+    success: bool
+    details: Optional[str] = None
+
+
+@app.post("/initialize", response_model=InitializeResponse)
+async def initialize(req: InitializeRequest):
+    """Handle MCP initialize request."""
+    return InitializeResponse(server="Yeshie MCP", capabilities=["actions", "logs"])
+
+
+@app.websocket("/ws/{tab_id}")
+async def websocket_endpoint(ws: WebSocket, tab_id: int):
+    """WebSocket endpoint used by Yeshie instances."""
+    await ws.accept()
+    _clients[tab_id] = ws
+    try:
+        while True:
+            data = await ws.receive_json()
+            fut = _pending.pop(tab_id, None)
+            if fut and not fut.done():
+                fut.set_result(ActionResponse(**data).dict())
+    except WebSocketDisconnect:
+        _clients.pop(tab_id, None)
+        fut = _pending.pop(tab_id, None)
+        if fut and not fut.done():
+            fut.set_result({"success": False, "details": "client disconnected"})
+
+
+@app.post("/actions", response_model=ActionResponse)
+async def send_actions(req: ActionRequest):
+    """Send an action script to a connected Yeshie tab and await the result."""
+    ws = _clients.get(req.tab_id)
+    if not ws:
+        return JSONResponse(status_code=404, content={"success": False, "details": "Tab not connected"})
+    loop = asyncio.get_event_loop()
+    fut: asyncio.Future = loop.create_future()
+    _pending[req.tab_id] = fut
+    await ws.send_json({"type": "actions", **req.dict()})
+    try:
+        result = await asyncio.wait_for(fut, timeout=10)
+        return result
+    except asyncio.TimeoutError:
+        _pending.pop(req.tab_id, None)
+        return ActionResponse(success=False, details="timeout waiting for client").dict()
+
+
+@app.post("/logs")
+async def receive_logs(entry: LogEntry):
+    """Receive diagnostic log entries."""
+    _logs.append(entry.dict())
+    return {"success": True}
+
+
+@app.get("/logs")
+async def get_logs():
+    """Retrieve all collected logs (debug use only)."""
+    return {"logs": _logs}

--- a/yeshie/server/test_mcp_server.py
+++ b/yeshie/server/test_mcp_server.py
@@ -1,0 +1,67 @@
+import asyncio
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from yeshie.server import mcp_server
+
+class DummyWebSocket:
+    def __init__(self):
+        self.sent = []
+        self.recv_queue = asyncio.Queue()
+        self.accepted = False
+
+    async def accept(self):
+        self.accepted = True
+
+    async def send_json(self, data):
+        self.sent.append(data)
+
+    async def receive_json(self):
+        return await self.recv_queue.get()
+
+def test_end_to_end_action_flow():
+    asyncio.run(run_flow())
+
+
+async def run_flow():
+    ws = DummyWebSocket()
+    ws_task = asyncio.create_task(mcp_server.websocket_endpoint(ws, tab_id=1))
+
+    # Initialize
+    init_resp = await mcp_server.initialize(mcp_server.InitializeRequest(client="test", version="0.1"))
+    assert init_resp.server == "Yeshie MCP"
+
+    # Send actions
+    action = mcp_server.Action(cmd="navto", target="https://example.com")
+    req = mcp_server.ActionRequest(tab_id=1, actions=[action])
+    send_task = asyncio.create_task(mcp_server.send_actions(req))
+
+    # Wait until websocket receives message
+    while not ws.sent:
+        await asyncio.sleep(0.01)
+    assert ws.sent[0]["type"] == "actions"
+    assert ws.sent[0]["actions"][0]["cmd"] == "navto"
+
+    # Send result back
+    await ws.recv_queue.put({"success": True, "details": "ok"})
+    resp = await send_task
+    assert resp == {"success": True, "details": "ok"}
+
+    # Send a log entry
+    log_entry = mcp_server.LogEntry(
+        tab_id=1,
+        timestamp="2024-01-01T00:00:00Z",
+        log_level="INFO",
+        message="test log"
+    )
+    await mcp_server.receive_logs(log_entry)
+    logs = (await mcp_server.get_logs())["logs"]
+    assert any(l["message"] == "test log" for l in logs)
+
+    ws_task.cancel()
+    try:
+        await ws_task
+    except asyncio.CancelledError:
+        pass


### PR DESCRIPTION
## Summary
- implement a FastAPI-based MCP server for Yeshie
- add basic end-to-end test with a dummy websocket client
- create minimal package initialization file

## Testing
- `pytest yeshie/server/test_mcp_server.py -q`
