### PR TITLE
Add MCP server with basic workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fastapi pydantic pytest
+      - name: Run MCP server tests
+        run: pytest yeshie/server/test_mcp_server.py -q
+

--- a/docs/cursor_integration.md
+++ b/docs/cursor_integration.md
@@ -30,3 +30,18 @@ These features can speed up code understanding and review tasks.
 Cursor ships as a complete editor, so you do **not** need to install a separate VS Code extension. If you previously used the Cursor extension inside VS Code, you can uninstall it and run the standalone IDE instead.
 
 
+
+## Automated MCP Workflow
+
+The MCP server located at `yeshie/server/mcp_server.py` provides a lightweight API for coordinating tests and browser actions.
+
+1. Start the server with `python yeshie/server/mcp_server.py`.
+2. The Chrome extension connects to `http://localhost:8123` and reports profile tabs.
+3. Pull requests trigger the GitHub Actions workflow which runs the MCP server tests.
+4. After merging, you can extend the server to pull updates and rebuild the extension automatically.
+
+The server exposes the following endpoints:
+
+- `GET /health` – simple health check.
+- `POST /logs` – accepts diagnostic log entries.
+- `POST /actions` – queues actions to be processed by the extension.

--- a/yeshie/server/mcp_server.py
+++ b/yeshie/server/mcp_server.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Optional
+
+app = FastAPI(
+    title="Yeshie MCP Server",
+    description="Receives logs and action requests from Yeshie agents.",
+    version="0.1.0",
+)
+
+class LogEntry(BaseModel):
+    tab_id: int
+    timestamp: str
+    log_level: str
+    message: str
+    context: Optional[dict] = None
+
+class Action(BaseModel):
+    cmd: str
+    target: str
+    value: Optional[str] = None
+
+class ActionRequest(BaseModel):
+    tab_id: int
+    actions: List[Action]
+
+class ActionResponse(BaseModel):
+    success: bool
+    details: Optional[str] = None
+
+logs: List[LogEntry] = []
+actions_received: List[ActionRequest] = []
+
+@app.get("/health")
+async def health():
+    """Simple health check."""
+    return {"status": "MCP server healthy"}
+
+@app.post("/logs")
+async def receive_logs(entry: LogEntry):
+    """Store a log entry sent from an agent."""
+    logs.append(entry)
+    return {"status": "received"}
+
+@app.post("/actions")
+async def perform_actions(request: ActionRequest):
+    """Accept an action request and queue it for processing."""
+    actions_received.append(request)
+    return ActionResponse(success=True, details="Actions queued")
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8123)
+

--- a/yeshie/server/test_mcp_server.py
+++ b/yeshie/server/test_mcp_server.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from mcp_server import health, receive_logs, perform_actions, LogEntry, Action, ActionRequest
+
+
+def test_health():
+    result = asyncio.run(health())
+    assert result == {"status": "MCP server healthy"}
+
+
+def test_receive_logs():
+    entry = LogEntry(tab_id=1, timestamp="2024-01-01T00:00:00Z", log_level="INFO", message="test")
+    resp = asyncio.run(receive_logs(entry))
+    assert resp == {"status": "received"}
+
+
+def test_perform_actions():
+    req = ActionRequest(tab_id=1, actions=[Action(cmd="navigate", target="https://example.com")])
+    resp = asyncio.run(perform_actions(req))
+    assert resp.success is True


### PR DESCRIPTION
## Summary
- implement Python MCP server with log and action endpoints
- add unit tests for MCP server
- document new automated workflow in Cursor integration guide
- set up CI workflow to run MCP server tests on every PR

## Testing
- `pytest yeshie/server/test_mcp_server.py -q`