### PR TITLE
Add MCP server with socket.io integration

### DIFF
--- a/docs/cursor_integration.md
+++ b/docs/cursor_integration.md
@@ -29,4 +29,9 @@ These features can speed up code understanding and review tasks.
 
 Cursor ships as a complete editor, so you do **not** need to install a separate VS Code extension. If you previously used the Cursor extension inside VS Code, you can uninstall it and run the standalone IDE instead.
 
+## Register the MCP Server
+
+Yeshie exposes a Model Context Protocol (MCP) server on port `8123`. After starting the server (`python yeshie/server/mcp_server.py` or `pnpm run mcp-server` inside the `extension` folder), open **Cursor** and navigate to **Settings → MCP Servers**.
+Add `http://localhost:8123` as a server URL so Cursor can issue actions and receive logs from Yeshie while you develop.
+
 

--- a/extension/background/index.ts
+++ b/extension/background/index.ts
@@ -1,6 +1,7 @@
 import { storageGet, storageSet, storageRemove } from "../functions/storage";
 import { logInfo, logWarn, logError } from "../functions/logger";
 import { initWebSocketHandlers } from "./websocket-handlers";
+import { initMCPClient } from "../functions/mcpClient";
 
 // Constants
 export const LAST_TAB_KEY = "yeshie_last_active_tab";
@@ -310,6 +311,9 @@ initTabTracking();
 
 // Initialize WebSocket handlers
 initWebSocketHandlers();
+
+// Connect to the MCP server for logs and actions
+initMCPClient();
 
 // Log initialization
 logInfo("Extension", "Background script initialized");

--- a/extension/functions/logger.ts
+++ b/extension/functions/logger.ts
@@ -10,6 +10,7 @@ const LOG_STORAGE_KEY = 'yeshieSessionLogs';
 
 // Now import dependencies
 import { storageGet, storageSet, storageRemove } from './storage'; // Import storage functions
+import { sendLogEntry } from './mcpClient';
 
 /**
  * Defines the possible levels for log messages.
@@ -163,6 +164,8 @@ function log(level: LogLevel, feature: string, message: string, context?: LogCon
 
   // Log to storage for the Log Viewer (asynchronously)
   logToStorage(logEntry);
+  // Forward log entry to MCP server if available
+  sendLogEntry(logEntry);
 }
 
 // --- Specific Helper Log Functions (Updated Signatures) ---

--- a/extension/functions/mcpClient.ts
+++ b/extension/functions/mcpClient.ts
@@ -1,0 +1,22 @@
+import { io, Socket } from "socket.io-client";
+import type { LogEntry } from "./logger";
+
+let socket: Socket | null = null;
+
+export function initMCPClient(url: string = "http://localhost:8123") {
+  socket = io(url);
+  socket.on("connect", () => {
+    console.debug("[MCP] connected", socket?.id);
+  });
+}
+
+export function sendLogEntry(entry: LogEntry) {
+  if (socket && socket.connected) {
+    socket.emit("log_entry", entry);
+  }
+}
+
+export function onActions(handler: (data: any) => void) {
+  if (!socket) return;
+  socket.on("actions", handler);
+}

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,7 +5,8 @@
   "description": "Yeshie Chrome Extension",
   "author": "Mike Wolf",
   "scripts": {
-    "dev:extension": "plasmo dev --verbose",
+    "dev:extension": "concurrently \"plasmo dev --verbose\" \"pnpm run mcp-server\"",
+    "mcp-server": "python ../yeshie/server/mcp_server.py",
     "dev": "pnpm run dev:extension",
     "build": "plasmo build",
     "package": "plasmo package"

--- a/yeshie/server/mcp_server.py
+++ b/yeshie/server/mcp_server.py
@@ -1,0 +1,181 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+import asyncio
+try:
+    import socketio  # type: ignore
+except Exception:  # pragma: no cover - fallback for test env
+    class _DummySocketIO:
+        def __init__(self, *a, **k):
+            pass
+
+        def event(self, fn):
+            return fn
+
+        def on(self, *a, **k):
+            def wrapper(fn):
+                return fn
+
+            return wrapper
+
+        async def emit(self, *a, **k):
+            pass
+
+    class socketio:  # type: ignore
+        AsyncServer = _DummySocketIO
+        ASGIApp = lambda *a, **k: a[1] if len(a) > 1 else a[0]
+
+import uvicorn
+
+app = FastAPI(
+    title="Yeshie MCP Server",
+    description="Minimal MCP server to interface with the Yeshie extension.",
+    version="0.1.0",
+)
+
+# Socket.IO server for extension communication
+sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+socket_app = socketio.ASGIApp(sio, other_asgi_app=app)
+
+# Connected clients indexed by tab_id
+_ws_clients: Dict[int, WebSocket] = {}
+_sio_clients: Dict[int, str] = {}
+# Futures waiting for action results
+_pending: Dict[int, asyncio.Future] = {}
+# In-memory log store
+_logs: List[Dict[str, Any]] = []
+
+
+class InitializeRequest(BaseModel):
+    client: str
+    version: str
+
+
+class InitializeResponse(BaseModel):
+    server: str
+    capabilities: List[str]
+
+
+class LogEntry(BaseModel):
+    tab_id: int
+    timestamp: str
+    log_level: str
+    message: str
+    context: Optional[Dict[str, Any]] = None
+
+
+class Action(BaseModel):
+    cmd: str
+    target: str
+    value: Optional[str] = None
+
+
+class ActionRequest(BaseModel):
+    tab_id: int
+    actions: List[Action]
+
+
+class ActionResponse(BaseModel):
+    success: bool
+    details: Optional[str] = None
+
+
+@app.post("/initialize", response_model=InitializeResponse)
+async def initialize(req: InitializeRequest):
+    """Handle MCP initialize request."""
+    return InitializeResponse(server="Yeshie MCP", capabilities=["actions", "logs"])
+
+
+@app.websocket("/ws/{tab_id}")
+async def websocket_endpoint(ws: WebSocket, tab_id: int):
+    """WebSocket endpoint used by Yeshie instances."""
+    await ws.accept()
+    _ws_clients[tab_id] = ws
+    try:
+        while True:
+            data = await ws.receive_json()
+            fut = _pending.pop(tab_id, None)
+            if fut and not fut.done():
+                fut.set_result(ActionResponse(**data).dict())
+    except WebSocketDisconnect:
+        _ws_clients.pop(tab_id, None)
+        fut = _pending.pop(tab_id, None)
+        if fut and not fut.done():
+            fut.set_result({"success": False, "details": "client disconnected"})
+
+
+@app.post("/actions", response_model=ActionResponse)
+async def send_actions(req: ActionRequest):
+    """Send an action script to a connected Yeshie tab and await the result."""
+    ws = _ws_clients.get(req.tab_id)
+    sid = _sio_clients.get(req.tab_id)
+    if not ws and not sid:
+        return JSONResponse(status_code=404, content={"success": False, "details": "Tab not connected"})
+    loop = asyncio.get_event_loop()
+    fut: asyncio.Future = loop.create_future()
+    _pending[req.tab_id] = fut
+    if ws:
+        await ws.send_json({"type": "actions", **req.dict()})
+    else:
+        await sio.emit("actions", req.dict(), to=sid)
+    try:
+        result = await asyncio.wait_for(fut, timeout=10)
+        return result
+    except asyncio.TimeoutError:
+        _pending.pop(req.tab_id, None)
+        return ActionResponse(success=False, details="timeout waiting for client").dict()
+
+
+@app.post("/logs")
+async def receive_logs(entry: LogEntry):
+    """Receive diagnostic log entries."""
+    _logs.append(entry.dict())
+    return {"success": True}
+
+
+@app.get("/logs")
+async def get_logs():
+    """Retrieve all collected logs (debug use only)."""
+    return {"logs": _logs}
+
+
+# --- Socket.IO Events ---
+
+@sio.event
+async def connect(sid, environ):
+    pass
+
+
+@sio.event
+async def disconnect(sid):
+    for tab_id, s in list(_sio_clients.items()):
+        if s == sid:
+            _sio_clients.pop(tab_id)
+            fut = _pending.pop(tab_id, None)
+            if fut and not fut.done():
+                fut.set_result({"success": False, "details": "client disconnected"})
+
+
+@sio.on("register_tab")
+async def register_tab(sid, data):
+    tab_id = data.get("tab_id")
+    if tab_id is not None:
+        _sio_clients[tab_id] = sid
+        await sio.emit("registered", {"tab_id": tab_id}, to=sid)
+
+
+@sio.on("action_result")
+async def action_result(sid, data):
+    tab_id = data.get("tab_id")
+    fut = _pending.pop(tab_id, None)
+    if fut and not fut.done():
+        fut.set_result({"success": data.get("success", False), "details": data.get("details")})
+
+
+@sio.on("log_entry")
+async def sio_log_entry(_sid, data):
+    _logs.append(data)
+
+if __name__ == "__main__":
+    uvicorn.run(socket_app, host="0.0.0.0", port=8123)

--- a/yeshie/server/test_mcp_server.py
+++ b/yeshie/server/test_mcp_server.py
@@ -1,0 +1,67 @@
+import asyncio
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from yeshie.server import mcp_server
+
+class DummyWebSocket:
+    def __init__(self):
+        self.sent = []
+        self.recv_queue = asyncio.Queue()
+        self.accepted = False
+
+    async def accept(self):
+        self.accepted = True
+
+    async def send_json(self, data):
+        self.sent.append(data)
+
+    async def receive_json(self):
+        return await self.recv_queue.get()
+
+def test_end_to_end_action_flow():
+    asyncio.run(run_flow())
+
+
+async def run_flow():
+    ws = DummyWebSocket()
+    ws_task = asyncio.create_task(mcp_server.websocket_endpoint(ws, tab_id=1))
+
+    # Initialize
+    init_resp = await mcp_server.initialize(mcp_server.InitializeRequest(client="test", version="0.1"))
+    assert init_resp.server == "Yeshie MCP"
+
+    # Send actions
+    action = mcp_server.Action(cmd="navto", target="https://example.com")
+    req = mcp_server.ActionRequest(tab_id=1, actions=[action])
+    send_task = asyncio.create_task(mcp_server.send_actions(req))
+
+    # Wait until websocket receives message
+    while not ws.sent:
+        await asyncio.sleep(0.01)
+    assert ws.sent[0]["type"] == "actions"
+    assert ws.sent[0]["actions"][0]["cmd"] == "navto"
+
+    # Send result back
+    await ws.recv_queue.put({"success": True, "details": "ok"})
+    resp = await send_task
+    assert resp == {"success": True, "details": "ok"}
+
+    # Send a log entry
+    log_entry = mcp_server.LogEntry(
+        tab_id=1,
+        timestamp="2024-01-01T00:00:00Z",
+        log_level="INFO",
+        message="test log"
+    )
+    await mcp_server.receive_logs(log_entry)
+    logs = (await mcp_server.get_logs())["logs"]
+    assert any(l["message"] == "test log" for l in logs)
+
+    ws_task.cancel()
+    try:
+        await ws_task
+    except asyncio.CancelledError:
+        pass


### PR DESCRIPTION
## Summary
- enhance Python-based MCP server with Socket.IO and fallback stub for tests
- forward extension logs to the MCP server via new mcpClient helper
- run MCP server alongside extension dev server
- document how to register the MCP server with Cursor

## Testing
- `pytest yeshie/server/test_mcp_server.py -q`
