### PR TITLE
Add Codex tasks for G-K

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -20,3 +20,4 @@ Additional task stubs have been created under the `tasks/` directory for upcomin
 - Task I – Always-listening SpeechInput with transcription toggle.
 - Task J – Comprehensive unit tests for SpeechInput.
 - Task K – Written test specification for SpeechInput.
+Codex task files for items G–K are available in the `codex_tasks/` directory.

--- a/codex_tasks/task_G_dialog_speech_input_integration.md
+++ b/codex_tasks/task_G_dialog_speech_input_integration.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from Task G in TASKS.md -->
+# Task G: Dialog Speech Input Integration
+
+## Summary
+Ensure all dialog components that collect text use the SpeechInput component so users can dictate instead of typing.
+
+## Acceptance Criteria
+- [ ] Every dialog with a text field renders `<SpeechInput>` instead of a raw `<textarea>` or `<input>`.
+- [ ] Dialogs automatically focus their SpeechInput when opened.
+- [ ] Manual typing remains possible without breaking SpeechInput features.
+
+## Implementation Notes
+- Audit the extension for dialogs such as ReportDialog, YeshieEditor, and any others that accept text.
+- Replace existing inputs with the SpeechInput component and wire up `onSubmit`/`onChange` props as needed.
+- Add ref handling so the SpeechInput textarea receives focus when the dialog becomes visible.

--- a/codex_tasks/task_H_singleton_speech_input.md
+++ b/codex_tasks/task_H_singleton_speech_input.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from Task H in TASKS.md -->
+# Task H: Singleton Speech Input Service
+
+## Summary
+Manage the SpeechInput recognition service globally so only the focused component in the active tab transcribes. The background script coordinates which component is active.
+
+## Acceptance Criteria
+- [ ] Only one SpeechInput instance is actively processing results at any time.
+- [ ] When tab focus changes, the SpeechInput in the newly focused tab gains control and others pause.
+- [ ] Losing focus stops transcription without shutting down the recognition service.
+
+## Implementation Notes
+- Each SpeechInput registers with the background script when it mounts and unregisters on unmount.
+- Use `chrome.tabs.onActivated` and `chrome.windows.onFocusChanged` listeners to track the active tab.
+- Background script sends messages to start or pause transcription based on focus events.

--- a/codex_tasks/task_I_transcribing_toggle.md
+++ b/codex_tasks/task_I_transcribing_toggle.md
@@ -1,0 +1,17 @@
+<!-- Codex task derived from Task I in TASKS.md -->
+# Task I: Always-Listening SpeechInput
+
+## Summary
+Refactor the SpeechInput component so the speech recognition service stays running in the background. Transcription of results only occurs when the mic icon is toggled on.
+
+## Acceptance Criteria
+- [ ] Recognition starts on mount and restarts automatically after `onend` or transient errors.
+- [ ] The mic button toggles an `isTranscribing` state without stopping the recognition service.
+- [ ] When `isTranscribing` is false, incoming results are ignored.
+- [ ] UI reflects the listening and transcribing states separately.
+
+## Implementation Notes
+- Start the recognition service once using `startListening` in an effect.
+- Keep it alive with a retry timer if the service ends unexpectedly.
+- Update `handleResult` to skip processing when transcription is disabled.
+- Adjust status messages and styles to clarify when the mic is listening but idle.

--- a/codex_tasks/task_J_speech_input_unit_tests.md
+++ b/codex_tasks/task_J_speech_input_unit_tests.md
@@ -1,0 +1,18 @@
+<!-- Codex task derived from Task J in TASKS.md -->
+# Task J: SpeechInput Unit Tests
+
+## Summary
+Create comprehensive unit tests covering SpeechInput behavior, including buffer insertion logic, cursor movement, and command timing.
+
+## Acceptance Criteria
+- [ ] Tests verify text is appended correctly when the cursor is at the end.
+- [ ] Tests verify insertion at an arbitrary cursor position preserves existing text.
+- [ ] Tests cover command interpretation with timing-sensitive phrases, e.g. "literally period" should output just "period" while "literally" *pause* "period" yields "literally".
+- [ ] Tests cover command interpretation such as "literally period" vs pauses around "literally".
+- [ ] Transcription toggle state is respected during tests.
+- [ ] All tests run via `pnpm test` and pass in CI.
+
+## Implementation Notes
+- Use Vitest and React Testing Library, mocking the SpeechRecognition API.
+- Simulate interim and final result events to test insertion logic.
+- Include cases where the user manually moves the cursor between recognition events.

--- a/codex_tasks/task_K_speech_input_test_spec.md
+++ b/codex_tasks/task_K_speech_input_test_spec.md
@@ -1,0 +1,17 @@
+<!-- Codex task derived from Task K in TASKS.md -->
+# Task K: SpeechInput Test Specification
+
+## Summary
+Write a detailed test specification covering manual and automated scenarios for the SpeechInput component. This document will guide future E2E tests and manual QA.
+
+## Acceptance Criteria
+- [ ] Document all command phrases and expected text output.
+- [ ] Include scenarios for text append vs insertion at the cursor.
+- [ ] Describe timing-sensitive cases such as pauses after "literally". Include specific examples like "literally period" vs "literally" *pause* "period".
+- [ ] Outline setup steps and any mocks needed for automated tests.
+- [ ] Spec lives under `docs` or `LLMNotes/testing`.
+
+## Implementation Notes
+- Base the spec on current SpeechInput logic in `extension/components/SpeechEditor.tsx`.
+- Provide clear example transcripts and resulting text for each case.
+- Link to this spec from `TASKS.md` for visibility.


### PR DESCRIPTION
## Summary
- create `codex_tasks/` folder with task files for items G–K
- reference new folder from `TASKS.md`

## Testing
- `pnpm test` *(fails: vitest not found)*