### PR TITLE
Create Codex tasks without altering project tasks

### DIFF
--- a/codex_tasks/task_B_stepper_command_tests.md
+++ b/codex_tasks/task_B_stepper_command_tests.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from tasks/task_B_stepper_command_tests.md -->
+# Task B: Unit Tests for Stepper Commands
+
+## Summary
+Create unit tests covering every command supported by the Stepper component. Tests should verify expected behavior in a controlled page and include error cases for invalid selectors or command arguments.
+
+## Acceptance Criteria
+- [ ] Tests exist for all Stepper commands (navto, click, type, waitforelement, etc.).
+- [ ] Error handling is tested for missing selectors and invalid commands.
+- [ ] Tests run via the existing test runner and pass in CI.
+
+## Implementation Notes
+- Use Playwright or the existing testing framework to drive a mock page.
+- Provide fixtures for pages with known selectors to exercise each command.
+- Document any limitations or assumptions in `LLMNotes/testing`.

--- a/codex_tasks/task_C_tab_panel_tests.md
+++ b/codex_tasks/task_C_tab_panel_tests.md
@@ -1,0 +1,16 @@
+<!-- Codex task derived from tasks/task_C_tab_panel_tests.md -->
+# Task C: Tab Panel Script Execution Tests
+
+## Summary
+Expand test coverage for the Tab page's script runner. Verify the Auto-run toggle, loading of `instructions.json`, step execution via Stepper, result writing, and archive/download behavior.
+
+## Acceptance Criteria
+- [ ] Toggling Auto-run loads instructions and begins execution automatically.
+- [ ] Steps are executed sequentially and recorded in `results.json`.
+- [ ] Success and failure toasts appear at the correct times.
+- [ ] Archived runs appear in the UI and can be downloaded.
+
+## Implementation Notes
+- Use Playwright to simulate toggling and monitor resulting behavior.
+- Mock file operations as needed to capture outputs.
+- Ensure tests run quickly by using a simple sample script.

--- a/codex_tasks/task_D_command_handler_ui_refresh.md
+++ b/codex_tasks/task_D_command_handler_ui_refresh.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from tasks/task_D_command_handler_ui_refresh.md -->
+# Task D: Background Command Handler and UI Refresh
+
+## Summary
+Implement the missing command execution handler in `background/messages/command.ts` and update the Tab page to refresh its task list after recordings are processed.
+
+## Acceptance Criteria
+- [ ] `command.ts` handles incoming commands and triggers appropriate Stepper actions.
+- [ ] Tab page updates its task list UI immediately after new recordings are saved.
+- [ ] No console errors occur during command handling or refresh.
+
+## Implementation Notes
+- Follow patterns from existing background message handlers.
+- Use messaging to notify the Tab page when recordings are processed.
+- Keep the UI update lightweight to avoid blocking user interactions.

--- a/codex_tasks/task_E_e2e_tests.md
+++ b/codex_tasks/task_E_e2e_tests.md
@@ -1,0 +1,16 @@
+<!-- Codex task derived from tasks/task_E_e2e_tests.md -->
+# Task E: Expanded E2E Tests
+
+## Summary
+Extend Playwright end-to-end tests as described in `LLMNotes/testing/test_plan.md`. Cover GitHub login recording, command execution, error handling, and archiving of test runs.
+
+## Acceptance Criteria
+- [ ] Tests automate GitHub login flow recording and replay.
+- [ ] Command execution failures generate helpful output and screenshots.
+- [ ] Archived runs can be viewed and verified in the Tab page.
+- [ ] CI passes with the new tests on a local development server.
+
+## Implementation Notes
+- Reuse existing E2E setup in `tests/e2e`.
+- Parameterize tests with environment variables for GitHub credentials.
+- Consult the test plan for prioritization and edge cases.

--- a/codex_tasks/task_F_bug_fixes_refactor.md
+++ b/codex_tasks/task_F_bug_fixes_refactor.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from tasks/task_F_bug_fixes_refactor.md -->
+# Task F: Bug Fixes and Refactoring
+
+## Summary
+Address outstanding bugs documented in `canvas/extension_review.md` and complete refactoring tasks per `refactor-plan.md` and `logging_refactor_checklist.md`. Ensure all new tests pass.
+
+## Acceptance Criteria
+- [ ] BUG-003, BUG-004, and BUG-005 are resolved with appropriate test coverage.
+- [ ] Codebase follows refactor checklist items still open.
+- [ ] No console warnings related to verbose logs or StrictMode issues.
+
+## Implementation Notes
+- Prioritize fixes that unblock other tasks, such as tab loading and focus.
+- Continue migrating console statements to the structured logger.
+- Review existing PRs or branches for partial implementations before starting.

--- a/codex_tasks/task_G_logger_cleanup.md
+++ b/codex_tasks/task_G_logger_cleanup.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from tasks/review/task_G_logger_cleanup.md -->
+# Task G: Logger Cleanup
+
+## Summary
+Replace all `console.log` and related debug statements across the extension with the structured logger utilities.
+
+## Acceptance Criteria
+- [ ] No remaining `console.log`, `console.warn`, or `console.error` statements in the `extension/` directory.
+- [ ] Existing behavior is preserved and logs appear through `logInfo`, `logWarn`, or `logError`.
+- [ ] All unit tests and lint checks continue to pass.
+
+## Implementation Notes
+- Search the entire `extension/` directory for console statements.
+- For trivial debugging statements that add no value, simply remove them.
+- For useful diagnostics, replace with the appropriate logger call.

--- a/codex_tasks/task_I_buildCounter_usage.md
+++ b/codex_tasks/task_I_buildCounter_usage.md
@@ -1,0 +1,14 @@
+<!-- Codex task derived from tasks/review/task_I_buildCounter_usage.md -->
+# Task I: Build Counter Review
+
+## Summary
+Clarify the purpose of `background/buildCounter.ts` and remove obsolete commented code. Ensure build information is consistently available to the extension UI and background scripts.
+
+## Acceptance Criteria
+- [ ] `getBuildInfo()` returns accurate version and build data in development and production.
+- [ ] Unused commented sections in `buildCounter.ts` are removed.
+- [ ] All callers (`tabs/index.tsx`, message handlers, reports) receive the same build info structure.
+
+## Implementation Notes
+- Decide whether build counters should reset on extension load or installation.
+- Document the expected format of the returned object in code comments.

--- a/codex_tasks/task_J_extcomms_review.md
+++ b/codex_tasks/task_J_extcomms_review.md
@@ -1,0 +1,14 @@
+<!-- Codex task derived from tasks/review/task_J_extcomms_review.md -->
+# Task J: Extcomms Review
+
+## Summary
+Audit `extension/functions/extcomms.ts` for unused functionality and clarify the communication flow between background and content scripts. The file currently mixes setup logic and message handling which can be confusing.
+
+## Acceptance Criteria
+- [ ] Documented overview of message types and expected payloads.
+- [ ] Unused handlers or variables are removed.
+- [ ] Setup functions for background and content scripts expose clear APIs.
+
+## Implementation Notes
+- Determine if socket.io connection logic belongs in this module or a separate service.
+- Ensure unit tests cover key messaging paths after refactoring.

--- a/codex_tasks/task_K_dead_code_audit.md
+++ b/codex_tasks/task_K_dead_code_audit.md
@@ -1,0 +1,14 @@
+<!-- Codex task derived from tasks/review/task_K_dead_code_audit.md -->
+# Task K: Dead Code Audit
+
+## Summary
+Perform a sweep of the `extension/` directory to identify modules, components, or functions that are no longer referenced. Remove them or write tests to prove they are still needed.
+
+## Acceptance Criteria
+- [ ] A list of unused files or functions is compiled and documented.
+- [ ] Dead code is removed with no loss of functionality.
+- [ ] All tests continue to pass after cleanup.
+
+## Implementation Notes
+- Use tools like TypeScript's `--noUnusedLocals` and `--noUnusedParameters` where possible.
+- Consider adding a linter rule to prevent future dead code accumulation.

--- a/codex_tasks/task_L_tab_tracking_extension_pages.md
+++ b/codex_tasks/task_L_tab_tracking_extension_pages.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from tasks/task_L_tab_tracking_extension_pages.md -->
+# Task L: Extension Page Tab Tracking
+
+## Summary
+Update tab tracking logic to include the control page and extension management pages, ensuring they appear in the Tab panel. Currently `tabHistory.ts` and `TabList.tsx` treat these as restricted URLs.
+
+## Acceptance Criteria
+- [ ] The control page and extension management page appear in the Tab panel list.
+- [ ] Switching to or from these pages updates the last active tab information.
+- [ ] Only internal `about:` pages continue to be ignored.
+
+## Implementation Notes
+- Modify `isExtensionUrl` in `tabHistory.ts` to only skip `about:` URLs.
+- Update `isRestrictedUrl` in `TabList.tsx` to allow `chrome-extension://` URLs for the Yeshie extension.
+- Add regression tests or manual steps verifying the Tab panel lists these pages.

--- a/codex_tasks/task_M_robust_selector_generation.md
+++ b/codex_tasks/task_M_robust_selector_generation.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from tasks/task_M_robust_selector_generation.md -->
+# Task M: Robust Selector Generation
+
+## Summary
+Implement a reliable `getRobustSelector` helper in `extension/functions/learn.ts` so recorded steps replay consistently.
+
+## Acceptance Criteria
+- [ ] Generated selectors uniquely identify elements across page reloads.
+- [ ] Selector generation handles IDs, classes, and hierarchy with minimal length.
+- [ ] Unit tests cover a variety of DOM structures.
+
+## Implementation Notes
+- Evaluate existing selector libraries or implement a heuristic approach.
+- Ensure fallback logic when elements lack IDs or stable attributes.
+- Document the algorithm in code comments for maintainability.

--- a/codex_tasks/task_N_orchestrator_langgraph_integration.md
+++ b/codex_tasks/task_N_orchestrator_langgraph_integration.md
@@ -1,0 +1,15 @@
+<!-- Codex task derived from tasks/task_N_orchestrator_langgraph_integration.md -->
+# Task N: Orchestrator LangGraph Integration
+
+## Summary
+Complete `yeshie/server/orchestrator.py` by wiring in LangGraph to manage agent workflows.
+
+## Acceptance Criteria
+- [ ] Orchestrator exposes endpoints to submit tasks and query status via LangGraph.
+- [ ] A small demo workflow runs in tests using mocked agents.
+- [ ] Server unit tests pass without requiring an external server.
+
+## Implementation Notes
+- Replace placeholder agent functions with minimal LangGraph nodes.
+- Use FastAPI's TestClient for unit tests.
+- Keep the interface compatible with the existing `test_orchestrator.py` expectations.


### PR DESCRIPTION
## Summary
- keep new Codex tasks for recent codebase review items
- remove duplicate task files from `tasks/` directory

## Testing
- `pytest yeshie/server/test_mcp_server.py -q`
