### PR TITLE
Adjust sidebar toggle size

### DIFF
--- a/extension/contents/Yeshie.tsx
+++ b/extension/contents/Yeshie.tsx
@@ -321,12 +321,12 @@ const Yeshie: React.FC = () => {
           boxShadow: "0 0 10px rgba(0, 0, 0, 0.1)"
         }}
         className={isOpen ? "open" : "closed"}>
-        <img 
-          src={iconBase64} 
-          alt="Yeshie Icon" 
+        <img
+          src={iconBase64}
+          alt="Yeshie Icon"
           className="resizing-icon"
-          width={32} 
-          height={32} 
+          width={16}
+          height={16}
         />
         <div style={{ 
           display: 'flex', 
@@ -363,8 +363,8 @@ const Yeshie: React.FC = () => {
           background: 'white',
           border: '1px solid #ddd',
           borderRadius: '50%',
-          width: '48px',
-          height: '48px',
+          width: '24px',
+          height: '24px',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -374,7 +374,7 @@ const Yeshie: React.FC = () => {
         }}
 
       >
-        <img src={iconBase64} alt="Yeshie Icon" width={32} height={32} />
+      <img src={iconBase64} alt="Yeshie Icon" width={16} height={16} />
       </button>
     </div>
   )

--- a/extension/css/google-sidebar-base.css
+++ b/extension/css/google-sidebar-base.css
@@ -51,8 +51,8 @@ body.plasmo-google-sidebar-show {
   background-color: white;
   border: 1px solid #ddd;
   border-radius: 50%;
-  width: 48px;
-  height: 48px;
+  width: 24px;
+  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -135,22 +135,24 @@ body.plasmo-google-sidebar-show {
 }
 
 /* Icon styles */
+
 .resizing-icon {
-  width: 64px;
-  height: 64px;
+  width: 32px;
+  height: 32px;
   transition: all 0.3s ease;
   margin: 0 auto;
   display: block;
+  opacity: 0.5;
 }
 
 .resizing-icon.small {
-  width: 24px;
-  height: 24px;
+  width: 12px;
+  height: 12px;
 }
 
 #yeshie-sidebar.open .resizing-icon {
-  width: 32px;
-  height: 32px;
+  width: 16px;
+  height: 16px;
 }
 
 #yeshie-sidebar p {

--- a/extension/css/google-sidebar.css
+++ b/extension/css/google-sidebar.css
@@ -12,15 +12,17 @@
 
   transition: all 0.5s ease;
 }
+
 .resizing-icon {
-  width: 128px;
-  height: 128px;
+  width: 64px;
+  height: 64px;
   transition: width 2s, height 2s;
+  opacity: 0.5;
 }
 
 #yeshie-sidebar.open .resizing-icon {
-  width: 32px;
-  height: 32px;
+  width: 16px;
+  height: 16px;
 }
 #yeshie-sidebar.open {
   left: calc(var(--plasmo-google-sidebar-width) * -1);


### PR DESCRIPTION
## Summary
- shrink the sidebar toggle button to match smaller icon
- keep icon semi-transparent at reduced size

## Testing
- `pytest yeshie/server/test_mcp_server.py -q`
