### PR TITLE
Fix SpeechInput punctuation and newline spacing

### DIFF
--- a/LLMNotes/testing/speech_input_test_spec.md
+++ b/LLMNotes/testing/speech_input_test_spec.md
@@ -41,7 +41,7 @@ The SpeechInput supports special phrases that translate into punctuation or cont
 | `close bracket` | `]` | space after |
 | `open brace` | `{` | space before |
 | `close brace` | `}` | space after |
-| `new line` | `\n` | removes trailing space before newline |
+| `new line` | `\n` | removes trailing space before newline; newline characters are preserved |
 | `all caps` | toggles uppercase mode | continues until `end caps` |
 | `end caps` | exit uppercase mode | |
 | `literally <command>` | inserts `<command>` text | e.g. `literally period` -> `period` |

--- a/client/src/tests/speechInput.test.tsx
+++ b/client/src/tests/speechInput.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
-import { SpeechInput } from '../../../extension/components/SpeechEditor';
+import { SpeechInput, processTranscriptSegmentImpl, shouldPrependSpace } from '../../../extension/components/SpeechEditor';
 
 // Simple smoke test to ensure component renders and accepts text
 
@@ -10,5 +10,27 @@ describe('SpeechInput', () => {
     const textarea = getByPlaceholderText(/enter text/i) as HTMLTextAreaElement;
     fireEvent.change(textarea, { target: { value: 'hello' } });
     expect(textarea.value).toBe('hello');
+  });
+
+  it('processes punctuation without leading space when spoken separately', () => {
+    const segment = 'period';
+    const result = processTranscriptSegmentImpl(segment, 'Hello world', { isAllCaps: false });
+    const needsSpace = shouldPrependSpace('Hello world', result);
+    const final = 'Hello world' + (needsSpace ? ' ' : '') + result;
+    expect(final).toBe('Hello world.');
+  });
+
+  it('preserves newline command', () => {
+    const segment = 'new line';
+    const result = processTranscriptSegmentImpl(segment, 'Hello', { isAllCaps: false });
+    expect(result).toBe('\n');
+  });
+
+  it('handles "literally" command in one utterance', () => {
+    const segment = 'literally period';
+    const result = processTranscriptSegmentImpl(segment, 'Test ', { isAllCaps: false });
+    const needsSpace = shouldPrependSpace('Test ', result);
+    const final = 'Test ' + (needsSpace ? ' ' : '') + result;
+    expect(final).toBe('Test period');
   });
 });

--- a/extension/docs/speech_prd.md
+++ b/extension/docs/speech_prd.md
@@ -13,8 +13,10 @@
 - Command word processing:
   - "literally" to type command words verbatim
   - "all caps" and "end caps" for capitalization control
-  - "new line" for paragraph breaks
-  - Various punctuation commands (period, comma, etc.)
+- "new line" for paragraph breaks
+- Various punctuation commands (period, comma, etc.)
+- Preserves new line characters in output so capitalization after a break works
+  consistently
 
 ### User Interface
 - Microphone toggle button with visual feedback


### PR DESCRIPTION
## Summary
- export `processTranscriptSegmentImpl` and `shouldPrependSpace`
- preserve newlines when processing speech segments
- refine spacing logic before punctuation
- update speech documentation
- extend unit tests for punctuation, newline, and `literally`

## Testing
- `pytest yeshie/server/test_mcp_server.py -q`
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e07817af4832f907278cfb7842a0c