### PR TITLE
Add Ajv validation for instruction files

### DIFF
--- a/extension/tabs/index.tsx
+++ b/extension/tabs/index.tsx
@@ -16,7 +16,7 @@ import LogViewer from "../components/LogViewer"; // Import the LogViewer compone
 import { Stepper } from '../functions/Stepper';
 import instructions from '../ipc/instructions.json';
 import schema from '../../llm-reply-schema.json';
-import { Validator } from 'jsonschema';
+import Ajv from 'ajv';
 import { ToastContainer, toast, Slide } from 'react-toastify'; // Added react-toastify imports
 import 'react-toastify/dist/ReactToastify.css'; // Added react-toastify CSS
 import TestViewerDialog from "../components/TestViewerDialog"; // Import the new dialog
@@ -26,12 +26,13 @@ import {
   type SliderMode 
 } from "../functions/globalSettings";
 
-const validator = new Validator();
+const ajv = new Ajv({ allErrors: true });
+const validateInstructions = ajv.compile(schema as any);
 
 function validateInstructionsData(data: any): string[] | null {
-  const result = validator.validate(data, schema as any);
-  if (!result.valid) {
-    return result.errors.map(e => `${e.property} ${e.message}`);
+  const valid = validateInstructions(data);
+  if (!valid) {
+    return (validateInstructions.errors || []).map((e) => `${e.instancePath} ${e.message}`);
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- validate `instructions.json` against `llm-reply-schema.json` using Ajv
- report validation errors in a toast and skip script execution

## Testing
- `pytest yeshie/server/test_mcp_server.py -q` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `pytest src/test_llmserver.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest tests/utils/test_helpers.py -q` *(fails: ModuleNotFoundError: No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_685e9c67cb0c832f8bdd7eaa84283e22